### PR TITLE
Assign TMB::compile if needed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,4 @@ License: MIT + file LICENSE
 URL:
 VignetteBuilder: knitr
 RoxygenNote: 6.1.0
+Remotes: github::John-R-Wallace/JRWToolBox, github::James-Thorson/VAST

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,5 @@
 Package: VASTWestCoast
 Version: 0.1
-Date: 2018-08-08
 Title: Estimation and simulation with VAST for the US West Coast
 Author: Kelli Faye Johnson <kelli.johnson@noaa.gov>
 Maintainer: Kelli Faye Johnson <kelli.johnson@noaa.gov>

--- a/R/VAST_condition.R
+++ b/R/VAST_condition.R
@@ -126,6 +126,12 @@ VAST_condition <- function(conditiondir, settings, spp,
   }
   save(Database, file = file.path(conditiondir, "DatabaseSave.RData"))
 
+  # ugly hack because VAST doesn't import compile()
+  if (!exists("compile", where = globalenv()) &&
+      !any(grepl("^package:TMBdebug$", search())) &&
+      !any(grepl("^package:TMB$", search())))
+    assign("compile", TMB::compile, envir = globalenv())
+
   info <- VAST_setup(data = Database,
     dir = kmeandir,
     regionacronym = survey,


### PR DESCRIPTION
This is a bad hack and will generate warnings when you check the package (that you can ignore) because it uses assign() to global, but I don't think there's any way around it without modifying VAST to not break package conventions. VAST must generate its own warnings about an undefined compile object. I guess an alternative is to just `library(TMB)` within your function if it or TMBdebug is not already loaded. I'm not sure if that's a greater or lesser evil. TMBdebug::compile looks so simple that it might be easier to just build a debug argument into VAST.

Honestly, a better solution is probably to import TMB::compile in VAST and then use assignInNamespace() in local scripts if a user wants to override the compile function with the debug variant.